### PR TITLE
enable background transfers

### DIFF
--- a/HalfTunes/AppDelegate.swift
+++ b/HalfTunes/AppDelegate.swift
@@ -40,8 +40,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   //
   // MARK: - Variables And Properties
-  //
   // TODO 17
+  ///If a background task completes when the app
+  /// isn’t running, the app will relaunch in the
+  /// background. You’ll need to handle this event
+  /// from your app delegate.
+  var backgroundSessionCompletionHandler: (() -> Void)?
+
   var window: UIWindow?
   
   //
@@ -54,7 +59,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   }
   
   // TODO 18
-  
+  ///Here, you save the provided completionHandler as a variable in your app delegate for later use.
+  ///application(_:handleEventsForBackgroundURLSession:) wakes up the app to deal with the
+  ///completed background task. You’ll need to handle two items in this method:
+  ///First, the app needs to recreate the appropriate background configuration and session using
+  ///the identifier provided by this delegate method. But since this app creates the background session
+  ///when it instantiates SearchViewController, you’re already reconnected at this point!
+  ///Second, you’ll need to capture the completion handler provided by this delegate method. Invoking
+  ///the completion handler tells the OS that your app’s done working with all background activities for
+  ///the current session. It also causes the OS to snapshot your updated UI for display in the app switcher.
+  func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession
+      handleEventsForBackgroundURLSessionidentifier: String,
+    completionHandler: @escaping () -> Void) {
+      backgroundSessionCompletionHandler = completionHandler
+  }
+  ///The place to invoke the provided completion handler is:
+  ///urlSessionDidFinishEvents(forBackgroundURLSession:), which is a URLSessionDelegate method
+  ///that fires when all tasks on the background session have finished.
+
   //
   // MARK - Private Methods
   //

--- a/HalfTunes/ViewControllers/SearchViewController.swift
+++ b/HalfTunes/ViewControllers/SearchViewController.swift
@@ -57,8 +57,14 @@ class SearchViewController: UIViewController {
   ///this lets you delay the creation of the session until after you initialize the view controller.
   ///Doing that allows you to pass self as the delegate parameter to the session initializer.
   lazy var downloadsSession: URLSession = {
-    /// set URLSessionConfiguration to  default configuration
-    let configuration = URLSessionConfiguration.default
+    ///used default configuration before but changed to background
+    ///in order to enable background downloads/transfers. Note that
+    ///you also set a unique identifier for the session to allow your
+    ///app to create a new background session, if needed.
+    ///NOTE: you must not crerate more than one session for a background
+    ///configuration because the system uses the configuration's identifier to
+    ///associated tasks with the session
+    let configuration = URLSessionConfiguration.background(withIdentifier: "guidedProjectHalfTunesByRayWenderlishDotCom")
     
     /// initialize a separate session with a default configuration
     /// specify a delegate which lets you receive `URLSession` events via delegate calls (useful for monitoring task progess)
@@ -232,6 +238,23 @@ extension SearchViewController: TrackCellDelegate {
 }
 
 // TODO 19
+///The code below grabs the stored completion handler from the app delegate and
+///invokes it on the main thread. You find the app delegate by getting the shared
+///instance of UIApplication, which is accessible thanks to the UIKit import.
+extension SearchViewController: URLSessionDelegate {
+  func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+    DispatchQueue.main.async {
+      if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+        let completionHandler = appDelegate.backgroundSessionCompletionHandler {
+        appDelegate.backgroundSessionCompletionHandler = nil
+        
+        completionHandler()
+      }
+    }
+  }
+}
+
+
 
 extension SearchViewController: URLSessionDownloadDelegate {
   


### PR DESCRIPTION
adds ability for downloads to continue when:
- app is in the background or
- if app crashes for any reason
NOTE:
If the user terminates the app by force-quitting
from the app switcher, the system will cancel all
the session's background transfers and will not
attempt to relaunch the app